### PR TITLE
🔥 Remove deprecated `experimentalObjectRestSpread` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module',
-    ecmaFeatures: { experimentalObjectRestSpread: true },
   },
   env: {
     browser: true,


### PR DESCRIPTION
See https://eslint.org/docs/user-guide/migrating-to-5.0.0#-the-experimentalobjectrestspread-option-has-been-deprecated