### PR TITLE
🎁 Add `react/sort-comp` and other React rules

### DIFF
--- a/react.js
+++ b/react.js
@@ -14,9 +14,13 @@ module.exports = {
   },
   plugins: ['@typescript-eslint', 'react'],
   extends: [
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/configs/recommended.json
     'plugin:@typescript-eslint/recommended',
+    // https://github.com/yannickcr/eslint-plugin-react#recommended
     'plugin:react/recommended',
+    // https://github.com/prettier/eslint-config-prettier/blob/master/%40typescript-eslint.js
     'prettier/@typescript-eslint',
+    // https://github.com/prettier/eslint-config-prettier/blob/master/react.js
     'prettier/react',
   ],
   settings: {
@@ -30,18 +34,108 @@ module.exports = {
     SharedArrayBuffer: 'readonly',
   },
   rules: {
-    'no-unused-vars': 'off',
+    /**
+     * We don't prefer `const`
+     * @see https://jamie.build/const
+     * @see https://madhatted.com/2016/1/25/let-it-be
+     * @see https://eslint.org/docs/rules/prefer-const
+     */
+    'prefer-const': 'off',
 
+    /**
+     * Enforce camelCase naming convention (ignores property names)
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/camelcase.md
+     */
+    '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
+
+    /**
+     * Require that interface names (not) be prefixed with `I`
+     * @see https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#names
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/interface-name-prefix.md
+     */
+    '@typescript-eslint/interface-name-prefix': 'off',
+
+    /**
+     * Disallow unused variables
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
+     */
     '@typescript-eslint/no-unused-vars': [
       'error',
       { vars: 'all', args: 'after-used', ignoreRestSiblings: false },
     ],
 
+    /**
+     * Disallows the use of require statements except in import statements
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-var-requires.md
+     */
+    '@typescript-eslint/no-var-requires': 'warn',
+
+    /**
+     * Restrict file extensions that may contain JSX
+     * @see https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md
+     */
     'react/jsx-filename-extension': [
       'warn',
       { extensions: ['.js', '.jsx', '.tsx'] },
     ],
-    'react/jsx-uses-vars': 'error',
-    'react/react--in-jsx-scope': 'off',
+
+    /**
+     * Prevent missing React when using JSX
+     * @see https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
+     */
+    'react/react-in-jsx-scope': 'off',
+
+    /**
+     * Enforce component methods order
+     * @see https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/sort-comp.md
+     */
+    'react/sort-comp': [
+      'error',
+      {
+        order: [
+          'static-variables',
+          'static-methods',
+          'instance-variables',
+          'lifecycle',
+          '/^handle.+$/',
+          'getters',
+          'setters',
+          '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
+          'instance-methods',
+          'everything-else',
+          'rendering',
+        ],
+        groups: {
+          lifecycle: [
+            'displayName',
+            'propTypes',
+            'contextTypes',
+            'childContextTypes',
+            'mixins',
+            'statics',
+            'defaultProps',
+            'constructor',
+            'getDefaultProps',
+            'getInitialState',
+            'state',
+            'getChildContext',
+            'getDerivedStateFromProps',
+            'componentWillMount',
+            'UNSAFE_componentWillMount',
+            'componentDidMount',
+            'componentWillReceiveProps',
+            'UNSAFE_componentWillReceiveProps',
+            'shouldComponentUpdate',
+            'componentWillUpdate',
+            'UNSAFE_componentWillUpdate',
+            'getSnapshotBeforeUpdate',
+            'componentDidUpdate',
+            'componentDidCatch',
+            'componentWillUnmount',
+          ],
+          rendering: ['/^render.+$/', 'render'],
+        },
+      },
+    ],
   },
 };


### PR DESCRIPTION
Other new rules are brought over from the main app.
`no-unused-vars` and `react/jsx-uses-vars` removed since they are set in
the extended configs.
Added links to docs around extended configs and individual rules.