### PR TITLE
Update: Switch to `naming-convention` rule

### DIFF
--- a/.changeset/warm-cups-smell.md
+++ b/.changeset/warm-cups-smell.md
@@ -3,6 +3,10 @@
 ---
 
 Switch to `naming-convention` TypeScript rule
+
 The `camelcase` and `interface-name-prefix` rules were deprecated in a
 previous typescript-eslint version. The former settings have been
 migrated to the new rule options.
+
+When upgrading to this version, make sure `@typescript-eslint/eslint-plugin`
+and `@typescript-eslint/parser` are upgraded to their latest as well.

--- a/.changeset/warm-cups-smell.md
+++ b/.changeset/warm-cups-smell.md
@@ -1,0 +1,8 @@
+---
+'@showbie/eslint-config': major
+---
+
+Switch to `naming-convention` TypeScript rule
+The `camelcase` and `interface-name-prefix` rules were deprecated in a
+previous typescript-eslint version. The former settings have been
+migrated to the new rule options.

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test": "npm run lint"
   },
   "optionalDependencies": {
-    "@typescript-eslint/eslint-plugin": "2.34.x",
-    "@typescript-eslint/parser": "2.34.x",
+    "@typescript-eslint/eslint-plugin": "4.9.x",
+    "@typescript-eslint/parser": "4.9.x",
     "eslint-plugin-ember": "8.12.x",
     "eslint-plugin-hbs": "0.1.2",
     "eslint-plugin-react": "7.20.x",

--- a/react.js
+++ b/react.js
@@ -45,17 +45,29 @@ module.exports = {
     'prefer-const': 'off',
 
     /**
-     * Enforce camelCase naming convention (ignores property names)
-     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/camelcase.md
+     * Enforce naming conventions
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md
      */
-    '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
-
-    /**
-     * Require that interface names (not) be prefixed with `I`
-     * @see https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#names
-     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/interface-name-prefix.md
-     */
-    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/naming-convention': [
+      'error',
+      /** Enforce camelCase naming convention (ignores property names) */
+      {
+        selector: 'property',
+        format: null,
+      },
+      /**
+       * Require that interface names (not) be prefixed with `I`
+       * @see https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#names
+       */
+      {
+        selector: 'interface',
+        format: ['PascalCase'],
+        custom: {
+          regex: '^I[A-Z]',
+          match: false,
+        },
+      },
+    ],
 
     /**
      * Disallow unused variables


### PR DESCRIPTION
The `camelcase` and `interface-name-prefix` rules were deprecated in a
previous typescript-eslint version. The former settings have been
migrated to the new rule options.
