### PR TITLE
Update: Add `no-empty-function` setting

### DIFF
--- a/.changeset/lucky-maps-move.md
+++ b/.changeset/lucky-maps-move.md
@@ -1,0 +1,7 @@
+---
+'@showbie/eslint-config-typescript': patch
+---
+
+Add `no-empty-function` setting
+Allows use in arrow functions, i.e. `() => {}`, which are currently used
+frequently in tests, default props, and Storybook examples.

--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -35,6 +35,16 @@ module.exports = {
     ],
 
     /**
+     * Disallow empty functions (except arrow functions)
+     * @see https://eslint.org/docs/rules/no-empty-function
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-empty-function.md
+     */
+    '@typescript-eslint/no-empty-function': [
+      'error',
+      { allow: ['arrowFunctions'] },
+    ],
+
+    /**
      * Disallow unused variables
      * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
      */


### PR DESCRIPTION
Allows use in arrow functions, i.e. `() => {}`, which are currently used
frequently in tests, default props, and Storybook examples.
